### PR TITLE
SCP synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Requirements:
 - pyOpenSSL (apt install python3-openssl)
 - merkle (pip3 install merkle)
 - SCION codebase (https://github.com/netsec-ethz/scion)
+- PySyncObj (git clone https://github.com/bakwc/PySyncObj.git)
+  (TODO(PSz): to be replaced by our fork with TCP/SCION)
 
 
 References:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements:
 - pyOpenSSL (apt install python3-openssl)
 - merkle (pip3 install merkle)
 - SCION codebase (https://github.com/netsec-ethz/scion)
-- PySyncObj (git clone https://github.com/bakwc/PySyncObj.git)
+- PySyncObj (pip3 install pysyncobj)
   (TODO(PSz): to be replaced by our fork with TCP/SCION)
 
 

--- a/lib/cert.py
+++ b/lib/cert.py
@@ -61,6 +61,9 @@ class EECert(object):
         # tmp.append("Policy: %s\n" % self.policy)
         return "".join(tmp)
 
+    def __eq__(self, other):
+        # Warning: __eq__() of *Entry objects is implemented differently!
+        return self.pack() == other.pack()
 
 class MSC(EECert):
     """

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -14,6 +14,7 @@
 from lib.errors import SCIONBaseError, SCIONVerificationError
 
 EEPKI_PORT = 9088
+EEPKI_SYNCH_PORT = 9089
 DEFAULT_CERT_VALIDITY = 120  # In days.
 POLICY_OID = "1.2.34.56.1"
 POLICY_BINDIND_OID = "1.2.34.56.2"

--- a/lib/scp_cache.py
+++ b/lib/scp_cache.py
@@ -14,6 +14,7 @@
 
 from pysyncobj import SyncObj, SyncObjConf, replicated
 
+from .cert import SCP
 from .defines import EEPKI_SYNCH_PORT
 
 
@@ -50,11 +51,13 @@ class SCPCache(object):
         self.list = ReplicatedList(my_addr, peers)
         self.last_idx = 0
 
-    def add(self, scp_raw):
-        self.list.append(scp_raw)
+    def add(self, scp):
+        self.list.append(scp.pack())
 
     def get_new(self):
+        res = []
         len_ = self.list.get_len()
-        res = self.list.get_data()[self.last_idx:]
+        for scp_raw in self.list.get_data()[self.last_idx:]:
+            res.append(SCP(scp_raw))
         self.last_idx = len_
         return res

--- a/lib/scp_cache.py
+++ b/lib/scp_cache.py
@@ -41,7 +41,7 @@ class SCPCache(object):
     def __init__(self, my_id, logs):
         my_addr = None
         peers = []
-        for id_ in logs:
+        for id_ in sorted(logs):  # TODO(PSz): is sorted() needed?
             addr = "%s:%d" % (logs[id_].addr.host, EEPKI_SYNCH_PORT)
             if id_ == my_id:
                 my_addr = addr

--- a/lib/scp_cache.py
+++ b/lib/scp_cache.py
@@ -1,0 +1,60 @@
+# Copyright 2017 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pysyncobj import SyncObj, SyncObjConf, replicated
+
+from .defines import EEPKI_SYNCH_PORT
+
+
+class ReplicatedList(SyncObj):
+    def __init__(self, my_addr, peers):
+        cfg = SyncObjConf(dynamicMembershipChange = True)
+        super().__init__(my_addr, peers, cfg)
+        self.__data = []
+
+    @replicated
+    def append(self, elem):
+        self.__data.append(elem)
+
+    def get(self, idx):
+        return self.__data[idx]
+
+    def get_len(self):
+        return len(self.__data)
+
+    def get_data(self):
+        return self.__data
+
+
+class SCPCache(object):
+    def __init__(self, my_id, logs):
+        my_addr = None
+        peers = []
+        for id_ in logs:
+            addr = "%s:%d" % (logs[id_].addr.host, EEPKI_SYNCH_PORT)
+            if id_ == my_id:
+                my_addr = addr
+            else:
+                peers.append(addr)
+        self.list = ReplicatedList(my_addr, peers)
+        self.last_idx = 0
+
+    def add(self, scp_raw):
+        self.list.append(scp_raw)
+
+    def get_new(self):
+        len_ = self.list.get_len()
+        res = self.list.get_data()[self.last_idx:]
+        self.last_idx = len_
+        return res

--- a/log/client.py
+++ b/log/client.py
@@ -166,5 +166,5 @@ if __name__ == "__main__":
     # connect to monitor(s) and confirm the root
     for monitor_id in sys.argv[4:]:
         cli.connect(monitor_id)
-        print(cli.confirm_root(root))
+        print(cli.confirm_root(root), end="\n\n")
         cli.close()

--- a/log/monitor.py
+++ b/log/monitor.py
@@ -99,7 +99,7 @@ class LogMonitor(EEPKIElement):
             return
         idx = msg.root_idx
         if idx in self.signed_roots[log_id] and msg != self.signed_roots[log_id][idx]:
-            logging.critical("Inconsistent roots: %s\n%s" % msg, self.signed_roots[log_id][idx])
+            logging.critical("Inconsistent roots: %s\n%s" % (msg, self.signed_roots[log_id][idx]))
             return
         self.signed_roots[log_id][idx] = msg
         logging.debug("Received root: %s" % msg)

--- a/log/server.py
+++ b/log/server.py
@@ -26,6 +26,7 @@ from pki.lib.msg import (
     SignedRoot,
     UpdateMsg,
 )
+from pki.lib.scp_cache import SCPCache
 from pki.lib.tree_entries import (
     CertificateEntry,
     MSCEntry,
@@ -71,6 +72,8 @@ class LogServer(EEPKIElement):
         self.revs_to_add = []
         self.signed_roots = []
         self.update_root()
+        # Init replicated cache
+        self.scp_cache = SCPCache(self.conf.my_id, self.conf.logs)
 
     def init_db(self):
         return []

--- a/tests.py
+++ b/tests.py
@@ -177,8 +177,6 @@ def test_cli_srv(mscs, scps):
     print("\nStarting client-server test. SCION must be running!!!")
     # First init server and client and connect
     cli_addr = SCIONAddr.from_values(ISD_AS("2-25"), haddr_parse(1, "127.2.2.2"))
-    srv_addr = SCIONAddr.from_values(ISD_AS("1-17"), haddr_parse(1, "127.1.1.1"))
-    # log_serv = LogServer(srv_addr)
     # threading.Thread(target=log_serv.run, name="LogServer", daemon=True).start()
     conf_file = OUTPUT_DIR + CONF_DIR + CONF_FILE
     cli = LogClient(cli_addr, conf_file)
@@ -193,6 +191,7 @@ def test_cli_srv(mscs, scps):
 def load_mscs_scps():
     mscs = {}
     scps = {}
+    old_dir = os.getcwd()
     os.chdir(OUTPUT_DIR)
     for name in glob.glob("*.msc"):
         domain_name = name[:-4]
@@ -208,6 +207,7 @@ def load_mscs_scps():
         scp = SCP(SCP(pem).pack())
         scps[domain_name] = scp
         assert scp.pack() == pem, "parse()/pack() failed"
+    os.chdir(old_dir)
     return mscs, scps
 
 


### PR DESCRIPTION
Log servers replicate accepted SCPs via Raft protocol (pysyncobj).
TODO: port pysyncobj to TCP/SCION